### PR TITLE
Agregar pruebas unitarias

### DIFF
--- a/src/main/java/Objetos/RegistroAcademico.java
+++ b/src/main/java/Objetos/RegistroAcademico.java
@@ -3,7 +3,7 @@ package Objetos;
 public class RegistroAcademico {
     private int anio;
     private String correlativo;
-    
+
     public RegistroAcademico(int anio, String correlativo){
         this.anio = anio;
         this.correlativo = correlativo;
@@ -24,17 +24,17 @@ public class RegistroAcademico {
     public void setCorrelativo(String correlativo) {
         this.correlativo = correlativo;
     }
-    
+
     public boolean cheequearCarnet(){
-        String carnet = this.anio+this.correlativo;
-        boolean chequeoTamanio = carnet.length() == 9 && String.valueOf(this.anio).length()==4;
+        String carnet = getAnio() + getCorrelativo();
+        boolean chequeoTamanio = carnet.length() == 9 && String.valueOf(getAnio()).length()==4;
         if(chequeoTamanio){
             try{
-                int chequeoCorrelativo = Integer.parseInt(this.correlativo);
+                int chequeoCorrelativo = Integer.parseInt(getCorrelativo());
                 if(anio > 1900){
                     return true;
                 }else{
-                    throw new Exception("Anio no valido.");
+                    throw new Exception("A�o no valido.");
                 }
             }catch(Exception e){
                 return false;
@@ -44,7 +44,7 @@ public class RegistroAcademico {
             return false;
         }
     }
-    
-    
-    
+
+
+
 }

--- a/src/main/java/Proceso/AsignarHorario.java
+++ b/src/main/java/Proceso/AsignarHorario.java
@@ -14,10 +14,7 @@ import java.util.List;
 
 public class AsignarHorario {
 
-    public AsignarHorario() {
-    }
-    
-    
+    public AsignarHorario() { }
 
     public Horario generarHorario(Carrera carrera, RegistroAcademico carnet) throws Exception {
         Horario horario = new Horario();

--- a/src/test/java/Proceso/EDGARMAURICIOGOMEZFLORES_201114340.java
+++ b/src/test/java/Proceso/EDGARMAURICIOGOMEZFLORES_201114340.java
@@ -1,0 +1,126 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package Proceso;
+
+import Objetos.Carrera;
+import Objetos.Horario;
+import Objetos.RegistroAcademico;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EDGARMAURICIOGOMEZFLORES_201114340 {
+
+    private AsignarHorario asignarHorario;
+    private Carrera carreraMock;
+    private RegistroAcademico registroAcademicoMock;
+
+    @Before
+    public void setup() {
+        carreraMock = mock(Carrera.class);
+        registroAcademicoMock = mock(RegistroAcademico.class);
+        asignarHorario = new AsignarHorario();
+    }
+
+    @Test
+    public void test_invalid_carnet_anio_returns_false() {
+        // Arrange
+        when(registroAcademicoMock.getAnio()).thenReturn(-999);
+        when(registroAcademicoMock.getCorrelativo()).thenReturn("14340");
+        // Act
+        boolean result = registroAcademicoMock.cheequearCarnet();
+        // Assert
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void test_invalid_carnet_length_returns_false() {
+        // Arrange
+        when(registroAcademicoMock.getAnio()).thenReturn(2011);
+        when(registroAcademicoMock.getCorrelativo()).thenReturn("143407");
+        // Act
+        boolean result = registroAcademicoMock.cheequearCarnet();
+        // Assert
+        Assert.assertFalse(result);
+    }
+
+    @Test(expected = Exception.class)
+    public void test_chequear_carnet_false_throws() throws Exception {
+        // Arrange
+        when(registroAcademicoMock.cheequearCarnet()).thenReturn(false);
+        // Act
+        asignarHorario.generarHorario(carreraMock, registroAcademicoMock);
+        // Assert
+        // Will throw
+    }
+
+    @Test
+    public void test_generar_horario_sucessfull_returns_null() throws Exception {
+        // Arrange
+        when(registroAcademicoMock.cheequearCarnet()).thenReturn(true);
+        when(carreraMock.procesarCarrera()).thenReturn(5);
+        when(registroAcademicoMock.getAnio()).thenReturn(2011);
+        // Act
+        Horario result = asignarHorario.generarHorario(carreraMock, registroAcademicoMock);
+        // Assert
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void test_invalid_codigo_carrera_doesnt_sets_codigo_horario() throws Exception {
+        // Arrange
+        when(registroAcademicoMock.cheequearCarnet()).thenReturn(true);
+        when(carreraMock.procesarCarrera()).thenReturn(5);
+        when(registroAcademicoMock.getAnio()).thenReturn(2011);
+        // Act
+        Horario result = asignarHorario.generarHorario(carreraMock, registroAcademicoMock);
+        // Assert
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void test_valid_codigo_carrera_does_sets_codigo_horario() throws Exception {
+        // Arrange
+        when(registroAcademicoMock.cheequearCarnet()).thenReturn(true);
+        when(carreraMock.procesarCarrera()).thenReturn(4);
+        when(registroAcademicoMock.getAnio()).thenReturn(2011);
+        // Act
+        Horario result = asignarHorario.generarHorario(carreraMock, registroAcademicoMock);
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getCodigoHorario(), 414);
+    }
+
+    @Test
+    public void test_invalid_procesar_carrera_returns_null() throws Exception {
+        // Arrange
+        when(registroAcademicoMock.cheequearCarnet()).thenReturn(true);
+        when(carreraMock.procesarCarrera()).thenReturn(5);
+        when(registroAcademicoMock.getAnio()).thenReturn(2011);
+        // Act
+        Horario result = asignarHorario.generarHorario(carreraMock, registroAcademicoMock);
+        // Assert
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void test_valid_procesar_carrera_does_sets_descripcion_horario() throws Exception {
+        // Arrange
+        when(registroAcademicoMock.cheequearCarnet()).thenReturn(true);
+        when(carreraMock.procesarCarrera()).thenReturn(2);
+        when(registroAcademicoMock.getAnio()).thenReturn(2011);
+        // Act
+        Horario result = asignarHorario.generarHorario(carreraMock, registroAcademicoMock);
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getCodigoHorario(), 265);
+        Assert.assertEquals(result.getDescripcion(), "Vespertino");
+    }
+
+}


### PR DESCRIPTION
## Hoja de trabajo 6

### Cambios

- Agregar pruebas unitarias para clase AsignarHorario en archivo `EDGARMAURICIOGOMEZFLORES_201114340`
- Agregar dos pruebas unitarias para clase RegistroAcademico en archivo `EDGARMAURICIOGOMEZFLORES_201114340`
- Modificar `cheequearCarnet` para utilizar getters en lugar de las propiedades `anio` y `correlativo`

### Screenshots

<img width="506" alt="Screen Shot 2020-09-21 at 20 59 10" src="https://user-images.githubusercontent.com/11670462/93840412-89097080-fc4d-11ea-9004-6aa126f074fc.png">
